### PR TITLE
add support for description

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export default ({
   trimRight,
   truncate,
   upperCase,
+  description,
 }) => {
   if (!name) {
     throw new Error('"name" is required');
@@ -172,6 +173,7 @@ export default ({
 
   return new GraphQLScalarType({
     name,
+    description,
     serialize: coerceString,
     parseValue,
     parseLiteral(ast) {


### PR DESCRIPTION
This PR adds support for passing a description string to GraphQLScalarType.
This enables a custom description per custom type created.