### PR TITLE
Added autogenerated descriptions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export default ({
   trimRight,
   truncate,
   upperCase,
+  description,
   ...config,
 }) => {
   if (!name) {
@@ -60,6 +61,35 @@ export default ({
         ast ? [ast] : []
       );
     };
+  }
+
+  if (!description && !test) {
+    // Autogenerate a description if no test is present
+    description = 'A string';
+    if (min && max) {
+      description += ` between ${min} and ${max} characters`
+    } else if (min) {
+      description += ` of at least ${min} characters`
+    } else if (max) {
+      description += ` at most ${max} characters`
+    }
+
+    if (pattern) {
+      if (description.length > 'A string'.length) {
+        description += ' and';
+      }
+      description += ` that matches the pattern '${pattern}'`;
+    }
+
+    if (trim || trimLeft || trimRight) {
+      if (trim) {
+        description += ' that is trimmed.';
+      } else {
+        description += `that is trimmed to the ${trimLeft ? 'left' : 'right'}.`;
+      }
+    } else {
+      description += '.';
+    }
   }
 
   const parseValue = (value, ast) => {
@@ -175,6 +205,7 @@ export default ({
     name,
     serialize: coerceString,
     parseValue,
+    description,
     parseLiteral(ast) {
       const {kind, value} = ast;
       if (kind === Kind.STRING) {

--- a/test/index.js
+++ b/test/index.js
@@ -449,4 +449,33 @@ describe('GraphQLInputString', () => {
       })
       .then(done, done);
   });
+
+  it('autodescriptors', () => {
+    let scalar = GraphQLInputString({
+              name: 'output',
+              min: 2,
+              trim: true,
+            });
+
+    expect(scalar.description).to.equal('A string of at least 2 characters that is trimmed.')
+
+    scalar = GraphQLInputString({
+              name: 'output',
+              min: 2,
+              max: 4,
+              trim: true,
+            });
+
+    expect(scalar.description).to.equal('A string between 2 and 4 characters that is trimmed.')
+
+    scalar = GraphQLInputString({
+              name: 'output',
+              min: 2,
+              max: 4,
+              trim: true,
+              description: 'A custom string.',
+            });
+
+    expect(scalar.description).to.equal('A custom string.')
+  });
 });


### PR DESCRIPTION
Here's an example of how the descriptions could be auto-generated. I like having descriptions as they help in the graphiql interface. The examples don't cover the full range of functionality but if a user wants to have complex value restrictions beyond the basics then perhaps he/she should take the time to properly explain the input. 